### PR TITLE
node modules following github packages naming weren't included

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ class ForgeExternalsPlugin {
       }
 
       for (const module of foundModules) {
-        if (file.startsWith(`/node_modules/${module}`)) {
+        if (file.startsWith(`/node_modules/${module.split("/")[0]}`)) {
           return false;
         }
       }


### PR DESCRIPTION
Github Packages naming conventions are mapped wrongly by Electron-Forge Ignore function.
Github Packages requires "@organization/package" name for libraries and Electron-Forge gives you just "node_modules/@organization".
If you want to open an issue on their GitHub feel free to do so.