### PR TITLE
include native node modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,6 @@ class ForgeExternalsPlugin {
         walker.modules = [];
         await walker.walkDependenciesForModule(moduleRoot, DepType.PROD);
         walker.modules
-          .filter((dep) => dep.nativeModuleType === DepType.PROD)
           .map((dep) => dep.name)
           .forEach((name) => foundModules.add(name));
       }


### PR DESCRIPTION
I'm trying to use this plugin with the [active-win](https://www.npmjs.com/package/active-win) module and having a problem. When I looked at the `node_modules` folder of the packaged app, I noticed that the `iconv`, `ref-napi`, and `ffi-napi` folders are empty.  If I include them in the packaged app, `active-win` will now work.

That's pretty much it, thanks.