### PR TITLE
Add getHooks method

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,12 @@ class ForgeExternalsPlugin {
     }
   }
 
+  getHooks() {
+    return {
+      "resolveForgeConfig": this.resolveForgeConfig
+    };
+  }
+
   resolveForgeConfig = async (forgeConfig) => {
     const foundModules = new Set(this._externals);
 


### PR DESCRIPTION
Webpack 5.75.0 appears to use getHooks and not getHook. Perhaps I have a configuration issue but adding getHooks fixed the issue for me.